### PR TITLE
task の追加機能修正（課題質問用　コミット）

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,13 +1,50 @@
 class TasksController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_board
 
   def index
     # @board = Board.find(params[:id])
-    @tasks = Task.all
+    @tasks = current_user.tasks
   end
 
   def show
-    @board = Board.find(params[:id])
-    @task = Task.find(params[:id])
+    @task = Task.all.find_by(id: params[:board_id])
+  end
+
+  def new
+    # ログイン中のユーザーとボード情報をセット
+    @task = @board.tasks.build(user: current_user)
+    @task.user = current_user
+  end
+
+  def create
+    # ログイン中のユーザーとボード情報をセット
+    @task = @board.tasks.build(task_params)
+    @task.user = current_user
+    if @task.save
+      # リダイレクト先は boards/show.haml
+      redirect_to board_path(@board), notice: '保存できたよ'
+    else
+      flash.now[:error] = '保存に失敗しました'
+      render :new
+    end
+  end
+
+  def edit
+    # ログイン中のユーザーとボード情報をセット
+    @task = @board.tasks.build(user: current_user)
+    @task.user = current_user
+  end
+
+  private
+
+  # URL パラメータから board_id を取得して設定
+  def set_board
+    @board = current_user.boards.find(params[:board_id])
+  end
+
+  # DB 保存する前にカラムに値が入っているかチェック
+  def task_params
+    params.require(:task).permit(:title, :summary)
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -20,6 +20,10 @@ class Task < ApplicationRecord
   # user が 複数の task に紐づいている (user_id)
   belongs_to :user
   belongs_to :board
+
+  # task に追加する画像を紐づける
+  has_one_attached :graphic
+
   # validates title, description が無いと保存しない
   validates :title, presence: true
   validates :summary, presence: true

--- a/app/views/boards/index.html.haml
+++ b/app/views/boards/index.html.haml
@@ -20,3 +20,6 @@
           .board_profInfo_text
             %p= board.author_name
             %p= board.display_created_at
+  = link_to new_board_path do
+    .board_add
+      + Add New Board

--- a/app/views/boards/show.haml
+++ b/app/views/boards/show.haml
@@ -1,28 +1,29 @@
 .container
   %h2
     = @board.title
-  .board
-    .board_text 
-      = @board.description
-    .board_profInfo
-      = image_tag @board.user.avatar_image, class: 'board_avatar'
-      .board_profInfo_text
-        %p= @board.author_name
-        %p= @board.display_created_at
+  -# .board
+  -#   .board_text 
+  -#     = @board.description
+  -#   .board_profInfo
+  -#     = image_tag @board.user.avatar_image, class: 'board_avatar'
+  -#     .board_profInfo_text
+  -#       %p= @board.author_name
+  -#       %p= @board.display_created_at
   .board
     - @tasks.each do |task|
-      .board_title 
-        = task.title
-      .board_text
-        = task.summary
-      .board_profInfo
-        = image_tag task.user.avatar_image, class: 'board_avatar'
-        .board_profInfo_text
-          %p= task.author_name
-          %p= task.display_created_at
-        
-        
-      = link_to 'タスクリンク', task_path(task)
-    -# taskが存在するなら、edit card に変更
-  .board_add
-    + Add new Card
+      = link_to board_task_path(task) do
+        .board_title 
+          = task.title
+        - if task.graphic.attached?
+          .board_graphic 
+            = image_tag task.graphic
+        .board_text
+          = task.summary
+        .board_profInfo
+          = image_tag task.user.avatar_image, class: 'board_avatar'
+          .board_profInfo_text
+            %p= task.author_name
+            %p= task.display_created_at
+  = link_to new_board_task_path(@board) do
+    .board_add
+      + Add new Card

--- a/app/views/tasks/_form.html.haml
+++ b/app/views/tasks/_form.html.haml
@@ -1,0 +1,24 @@
+.container
+  %ul
+    - task.errors.full_messages.each do |message|
+      %li= message
+  %h2 New Card
+  = form_with(model: [@board, task], local: true, data: { turbo: false } ) do |f| 
+    %div
+      = f.label :graphic,'image'
+    %div
+      = f.file_field :graphic
+    %div
+      = f.label :title, 'Name'
+    %div
+      = f.text_field :title, class: 'text'
+    %div
+      = f.label :summary, 'summary'
+    %div
+      = f.text_field :summary, class: 'text'
+    %div
+      = f.label :detail, 'Description'
+    %div
+      = f.text_area :detail
+    %div
+      = f.submit 'Submit', class: 'btn-submit'

--- a/app/views/tasks/edit.html.haml
+++ b/app/views/tasks/edit.html.haml
@@ -1,0 +1,1 @@
+= render 'form', task: @task

--- a/app/views/tasks/new.html.haml
+++ b/app/views/tasks/new.html.haml
@@ -1,0 +1,3 @@
+-# board は task に board_id に紐づけが必要
+-# form_with がネストされた board_tasks_path を使用して task が board に関連付け
+= render 'form', task: @task, board: @board

--- a/app/views/tasks/show.html.haml
+++ b/app/views/tasks/show.html.haml
@@ -1,7 +1,5 @@
 .container
   %h2 SHOW タスク詳細
-  .board_title
-    = @board.title
   .task_title
     = @task.title
   .task_summary

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,8 @@ Rails.application.routes.draw do
   devise_for :users
   root to: 'boards#index'
 
-  resources :boards
-  resources :tasks
+  resources :boards do
+    resources :tasks
+  end
   resource :profile, only: [:show, :edit, :update]
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -18,11 +18,6 @@ emily = User.create!(email: 'emily@example.com', password: 'password')
     title: Faker::Lorem.sentence(word_count: 4),
     description: Faker::Lorem.sentence(word_count: 20)
   )
-  jon.tasks.create(
-    title: Faker::Lorem.sentence(word_count: 3),
-    summary: Faker::Lorem.sentence(word_count: 5),
-    detail: Faker::Lorem.sentence(word_count: 10)
-  )
 end
 
 5.times do


### PR DESCRIPTION
注意：エラーあり（原因調査対象）

① Taskの追加でエラー
② Couldn't find Board with 'id'=1 [WHERE "boards"."user_id" = $1]　とでるので、作成した ボードとuser_id が見つけられない
③ sql を確認すると detail 部分が入力されていない
taskapp_development=# \dt
                     List of relations
 Schema |              Name              | Type  |  Owner
--------+--------------------------------+-------+---------
 public | active_storage_attachments     | table | appuser
 public | active_storage_blobs           | table | appuser
 public | active_storage_variant_records | table | appuser
 public | ar_internal_metadata           | table | appuser
 public | boards                         | table | appuser
 public | profiles                       | table | appuser
 public | schema_migrations              | table | appuser
 public | tasks                          | table | appuser
 public | users                          | table | appuser

 id | user_id | board_id | title |                    summary                     | detail |         created_at         |         updated_at
----+---------+----------+-------+------------------------------------------------+--------+----------------------------+----------------------------
  1 |       3 |       11 | AAAA  | ああああああああｄｄｄｄｄｄｄｄｄｄｄｄｄｄｄ |        | 2024-10-21 12:44:11.667755 | 2024-10-21 12:44:11.667755